### PR TITLE
- Chord: Convert flat symbol to b when get chord

### DIFF
--- a/src/Block.php
+++ b/src/Block.php
@@ -46,7 +46,9 @@ class Block {
         if (null !== $this->chord) {
             $chords = explode('/',$this->englishNotation($this->chord));
             foreach ($chords as $chord) {
-                $result[] = [substr($chord,0,1),substr($chord,1)];
+                $secondPart = substr($chord, 1);
+                $secondPart = str_replace('♭', 'b', $secondPart);
+                $result[] = [substr($chord,0,1),$secondPart];
             }
             return $result;
         }


### PR DESCRIPTION
Previously, when transposing from `F` to `A`, the `B♭` chords were being transposed from `B` to `D♯` and then `♭` was being tacked on the end. Converting `♭` to `b` allows `B♭` to be transposed to `D`.